### PR TITLE
Allow nullable fields

### DIFF
--- a/lib/smart_params.rb
+++ b/lib/smart_params.rb
@@ -1,11 +1,8 @@
 require "dry-types"
-require "dry/monads/maybe"
 require "recursive-open-struct"
 require "active_support/concern"
 require "active_support/core_ext/object"
 require "active_support/core_ext/module/delegation"
-
-Dry::Types.load_extensions(:maybe)
 
 module SmartParams
   extend ActiveSupport::Concern

--- a/lib/smart_params.rb
+++ b/lib/smart_params.rb
@@ -6,7 +6,7 @@ require "active_support/core_ext/module/delegation"
 
 module SmartParams
   extend ActiveSupport::Concern
-  include Dry::Types.module
+  include Dry.Types()
 
   require_relative "smart_params/field"
   require_relative "smart_params/error"

--- a/lib/smart_params.rb
+++ b/lib/smart_params.rb
@@ -68,7 +68,7 @@ module SmartParams
   # This function basically takes a list of fields and reduces them into a tree of values
   private def structure
     fields
-      .reject(&:remove?)
+      .reject(&:removable?)
       .map(&:to_hash)
       .reduce(&:deep_merge)
   end

--- a/lib/smart_params.rb
+++ b/lib/smart_params.rb
@@ -1,8 +1,11 @@
 require "dry-types"
+require "dry/monads/maybe"
 require "recursive-open-struct"
 require "active_support/concern"
 require "active_support/core_ext/object"
 require "active_support/core_ext/module/delegation"
+
+Dry::Types.load_extensions(:maybe)
 
 module SmartParams
   extend ActiveSupport::Concern
@@ -68,12 +71,8 @@ module SmartParams
   # This function basically takes a list of fields and reduces them into a tree of values
   private def structure
     fields
-      .reject(&:empty?)
+      .reject(&:remove?)
       .map(&:to_hash)
-      .map do |hash|
-        # NOTE: okay, so this looks weird, but it's because the root type has no key
-        if hash.key?(nil) then hash.fetch(nil) else hash end
-      end
       .reduce(&:deep_merge)
   end
 

--- a/lib/smart_params/field.rb
+++ b/lib/smart_params/field.rb
@@ -79,8 +79,8 @@ module SmartParams
       value.nil?
     end
 
-    # Remove from resulting hash?
-    def remove?
+    # Should this field be removed from resulting hash?
+    def removable?
       empty? && !allow_empty?
     end
 

--- a/lib/smart_params/field.rb
+++ b/lib/smart_params/field.rb
@@ -1,14 +1,16 @@
 module SmartParams
   class Field
     attr_reader :keychain
-    attr_reader :value
     attr_reader :subfields
     attr_reader :type
 
-    def initialize(keychain:, type:, &nesting)
+    def initialize(keychain:, type:, nullable: false, &nesting)
       @keychain = Array(keychain)
       @subfields = Set.new
       @type = type
+      @nullable = nullable
+      @specified = false
+      @dirty = false
 
       if block_given?
         instance_eval(&nesting)
@@ -17,6 +19,46 @@ module SmartParams
 
     def deep?
       subfields.present?
+    end
+
+    def root?
+      keychain.size == 0
+    end
+
+    def value
+      @value || ({} if root?)
+    end
+
+    def nullable?
+      !!@nullable
+    end
+
+    def specified?
+      if nullable?
+        !!@specified && clean?
+      else
+        !!@specified
+      end
+    end
+
+    # For nullable hashes: Any keys not in the schema make the hash dirty.
+    # If a key is found that matches the schema, we can consider the hash
+    # clean.
+    def dirty?
+      !!@dirty
+    end
+
+    def clean?
+      return false if dirty?
+      return true if empty? || subfields.select { |sub| !sub.empty? }.any?
+      false
+    end
+
+    # Check if we should consider this value even when empty.
+    def allow_empty?
+      return true if specified? && nullable?
+      return subfields.select(&:allow_empty?).any?
+      false
     end
 
     def claim(raw)
@@ -28,7 +70,7 @@ module SmartParams
     end
 
     def to_hash
-      keychain.reverse.reduce(value) do |accumulation, key|
+      v = keychain.reverse.reduce(value) do |accumulation, key|
         { key => accumulation }
       end
     end
@@ -37,20 +79,48 @@ module SmartParams
       value.nil?
     end
 
+    # Remove from resulting hash?
+    def remove?
+      empty? && !allow_empty?
+    end
+
     def weight
       keychain.map(&:to_s)
     end
 
-    private def field(key, type:, &subfield)
-      @subfields << self.class.new(keychain: [*keychain, key], type: type, &subfield)
+    private def field(key, type:, nullable: false, &subfield)
+      @subfields << self.class.new(keychain: [*keychain, key], type: type, nullable: nullable, &subfield)
     end
 
+    # Very busy method with recent changes. TODO: clean-up
     private def dug(raw)
-      if keychain.empty?
-        raw
-      else
-        raw.dig(*keychain)
+      return raw if keychain.empty?
+
+      # If value provided is a hash, check if it's dirty. See #dirty? for
+      # more info.
+      if nullable?
+        hash = raw.dig(*keychain)
+        if hash.respond_to?(:keys)
+          others =  hash.keys - [keychain.last]
+          @dirty = others.any?
+        end
       end
+
+      # Trace the keychain to find out if the field is explicitly set in the
+      # input hash.
+      at = raw
+      exact = true
+      keychain.each { |key|
+        if at.respond_to?(:key?) && at.key?(key)
+          at = at[key]
+        else
+          exact = false
+          break
+        end
+      }
+      @specified = exact
+
+      raw.dig(*keychain)
     end
   end
 end

--- a/lib/smart_params/field.rb
+++ b/lib/smart_params/field.rb
@@ -70,7 +70,7 @@ module SmartParams
     end
 
     def to_hash
-      v = keychain.reverse.reduce(value) do |accumulation, key|
+      keychain.reverse.reduce(value) do |accumulation, key|
         { key => accumulation }
       end
     end

--- a/lib/smart_params_spec.rb
+++ b/lib/smart_params_spec.rb
@@ -2,6 +2,7 @@ require "spec_helper"
 
 RSpec.describe SmartParams do
   let(:schema) { CreateAccountSchema.new(params) }
+  let(:update_schema) { UpdateAccountSchema.new(params) }
 
   describe ".new" do
     context "with an empty params" do
@@ -370,6 +371,229 @@ RSpec.describe SmartParams do
           ]
         )
       end
+    end
+  end
+
+  context "with nil relationship" do
+    subject {update_schema.to_hash}
+
+    let(:params) do
+      {
+        data: {
+          id: "1",
+          type: "accounts",
+          attributes: {
+            email: "kurtis@example.com",
+            password: "new_secret"
+          },
+          relationships: {
+            owner: {
+              data: nil
+            }
+          }
+        },
+        meta: {
+          jsonapi_version: "1.0"
+        }
+      }
+    end
+
+    it "returns nil data" do
+      expect(
+        subject
+      ).to match(
+        hash_including(
+          {
+            "data" => hash_including(
+              {
+                "id" => "1",
+                "type" => "accounts",
+                "attributes" => hash_including(
+                  {
+                    "email" => "kurtis@example.com",
+                    "password" => an_instance_of(String)
+                  }
+                ),
+                "relationships" => hash_including(
+                  {
+                    "owner" => hash_including(
+                      {
+                        "data" => nil
+                      }
+                    )
+                  }
+                )
+              }
+            ),
+            "meta" => {
+              "jsonapi_version" => "1.0"
+            }
+          }
+        )
+      )
+    end
+  end
+
+  context "with updated relationship" do
+    subject {update_schema.to_hash}
+
+    let(:params) do
+      {
+        data: {
+          id: "1",
+          type: "accounts",
+          attributes: {
+            email: "kurtis@example.com",
+            password: "new_secret"
+          },
+          relationships: {
+            owner: {
+              data: {
+                id: 1,
+                type: "people"
+              }
+            }
+          }
+        },
+        meta: {
+          jsonapi_version: "1.0"
+        }
+      }
+    end
+
+    it "returns nil data" do
+      expect(
+        subject
+      ).to match(
+        hash_including(
+          {
+            "data" => hash_including(
+              {
+                "id" => "1",
+                "type" => "accounts",
+                "attributes" => hash_including(
+                  {
+                    "email" => "kurtis@example.com",
+                    "password" => an_instance_of(String)
+                  }
+                ),
+                "relationships" => hash_including(
+                  {
+                    "owner" => hash_including(
+                      {
+                        "data" => hash_including(
+                          {
+                            "id" => "1",
+                            "type" => "people"
+                          }
+                        )
+                      }
+                    )
+                  }
+                )
+              }
+            ),
+            "meta" => {
+              "jsonapi_version" => "1.0"
+            }
+          }
+        )
+      )
+    end
+  end
+
+  context "with nullable field not set" do
+    subject {update_schema.to_hash}
+
+    let(:params) do
+      {
+        data: {
+          id: "1",
+          type: "accounts",
+          attributes: {
+            email: "kurtis@example.com",
+            password: "new_secret"
+          }
+        },
+        meta: {
+          jsonapi_version: "1.0"
+        }
+      }
+    end
+
+    it "does not set nil relationship" do
+      expect(
+        subject
+      ).to match(
+        hash_including(
+          {
+            "data" => hash_excluding(
+              {
+                "relationships" => hash_including(
+                  {
+                    "owner" => hash_including(
+                      {
+                        "data" => nil
+                      }
+                    )
+                  }
+                )
+              }
+            )
+          }
+        )
+      )
+    end
+  end
+
+  context "with spoofed nil relationship" do
+    subject {update_schema.to_hash}
+
+    let(:params) do
+      {
+        data: {
+          id: "1",
+          type: "accounts",
+          attributes: {
+            email: "kurtis@example.com",
+            password: "new_secret"
+          },
+          relationships: {
+            owner: {
+              data: {
+                is: "garbage"
+              }
+            }
+          }
+        },
+        meta: {
+          jsonapi_version: "1.0"
+        }
+      }
+    end
+
+    it "does not set nil relationship" do
+      expect(
+        subject
+      ).to match(
+        hash_including(
+          {
+            "data" => hash_excluding(
+              {
+                "relationships" => hash_including(
+                  {
+                    "owner" => hash_including(
+                      {
+                        "data" => nil
+                      }
+                    )
+                  }
+                )
+              }
+            )
+          }
+        )
+      )
     end
   end
 end

--- a/lib/smart_params_spec.rb
+++ b/lib/smart_params_spec.rb
@@ -42,7 +42,8 @@ RSpec.describe SmartParams do
           data: {
             type: "accounts",
             attributes: {
-              email: "kurtis@example.com"
+              email: "kurtis@example.com",
+              password: "secret"
             }
           },
           meta: {
@@ -155,7 +156,8 @@ RSpec.describe SmartParams do
           data: {
             type: "accounts",
             attributes: {
-              email: "kurtis@example.com"
+              email: "kurtis@example.com",
+              password: "secret"
             }
           },
           meta: {
@@ -234,7 +236,8 @@ RSpec.describe SmartParams do
           data: {
             type: "accounts",
             attributes: {
-              email: "kurtis@example.com"
+              email: "kurtis@example.com",
+              password: "secret"
             }
           },
           meta: {
@@ -322,7 +325,8 @@ RSpec.describe SmartParams do
           data: {
             type: "accounts",
             attributes: {
-              email: "kurtis@example.com"
+              email: "kurtis@example.com",
+              password: "secret"
             }
           },
           meta: {

--- a/smart_params.gemspec
+++ b/smart_params.gemspec
@@ -26,5 +26,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-doc", "~> 0.11"
   spec.add_runtime_dependency "activesupport", ">= 4.0.0", ">= 4.1", ">= 5.0.0", ">= 5.2"
   spec.add_runtime_dependency "dry-types", "~> 0.12"
+  spec.add_runtime_dependency "dry-monads", "~> 1.2.0"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1"
 end

--- a/smart_params.gemspec
+++ b/smart_params.gemspec
@@ -26,6 +26,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry-doc", "~> 0.11"
   spec.add_runtime_dependency "activesupport", ">= 4.0.0", ">= 4.1", ">= 5.0.0", ">= 5.2"
   spec.add_runtime_dependency "dry-types", "~> 0.12"
-  spec.add_runtime_dependency "dry-monads", "~> 1.2.0"
   spec.add_runtime_dependency "recursive-open-struct", "~> 1.1"
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,4 @@
 require "pry"
-require "rspec"
 require "smart_params"
 require "securerandom"
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,6 +21,33 @@ class CreateAccountSchema
   end
 end
 
+class UpdateAccountSchema
+  include SmartParams
+
+  schema type: Strict::Hash do
+    field :data, type: Strict::Hash do
+      field :id, type: Coercible::String.optional
+      field :type, type: Strict::String
+      field :attributes, type: Strict::Hash.optional do
+        field :email, type: Strict::String.optional
+        field :username, type: Strict::String.optional
+        field "full-name", type: Strict::String.optional
+        field :password, type: Strict::String.optional
+      end
+      field :relationships, type: Strict::Hash.optional do
+        field :owner, type: Strict::Hash.optional do
+          field :data, type: Strict::Hash.optional.maybe, nullable: true do
+            field :id, type: Coercible::String.optional
+            field :type, type: Strict::String.optional
+          end
+        end
+      end
+    end
+    field :meta, type: Strict::Hash.optional
+    field :included, type: Strict::Array.optional
+  end
+end
+
 RSpec.configure do |let|
   # Enable flags like --only-failures and --next-failure
   let.example_status_persistence_file_path = ".rspec_status"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -21,30 +21,14 @@ class CreateAccountSchema
   end
 end
 
-class UpdateAccountSchema
+class NullableSchema
   include SmartParams
 
   schema type: Strict::Hash do
-    field :data, type: Strict::Hash do
+    field :data, type: Strict::Hash | Strict::Nil, nullable: true do
       field :id, type: Coercible::String.optional
-      field :type, type: Strict::String
-      field :attributes, type: Strict::Hash.optional do
-        field :email, type: Strict::String.optional
-        field :username, type: Strict::String.optional
-        field "full-name", type: Strict::String.optional
-        field :password, type: Strict::String.optional
-      end
-      field :relationships, type: Strict::Hash.optional do
-        field :owner, type: Strict::Hash.optional do
-          field :data, type: Strict::Hash.optional.maybe, nullable: true do
-            field :id, type: Coercible::String.optional
-            field :type, type: Strict::String.optional
-          end
-        end
-      end
+      field :type, type: Strict::String.optional
     end
-    field :meta, type: Strict::Hash.optional
-    field :included, type: Strict::Array.optional
   end
 end
 


### PR DESCRIPTION
This is a pretty big change. Adds the ability to mark fields in your schema as nullable, meaning you can explicitly set them to `nil` in the input and they will pass through to the output as `nil`. Use case I had in mind was scrubbing parameters for JSON:API relationship removals.