### PR TITLE
Nullable schema constraints

### DIFF
--- a/lib/smart_params/field.rb
+++ b/lib/smart_params/field.rb
@@ -18,6 +18,9 @@ module SmartParams
     end
 
     def deep?
+      # We check @specified directly because we want to know if ANY
+      # subfields have been passed, not just ones that match the schema.
+      return false if nullable? && !!@specified
       subfields.present?
     end
 

--- a/lib/smart_params_spec.rb
+++ b/lib/smart_params_spec.rb
@@ -507,7 +507,7 @@ RSpec.describe SmartParams do
       it "checks subfields" do
         expect {
           subject
-        }.not_to raise_exception(SmartParams::Error::InvalidPropertyType)
+        }.not_to raise_exception
       end
     end
 
@@ -524,7 +524,7 @@ RSpec.describe SmartParams do
       it "allows null value" do
         expect {
           subject
-        }.not_to raise_error
+        }.not_to raise_exception
       end
     end
   end

--- a/lib/smart_params_spec.rb
+++ b/lib/smart_params_spec.rb
@@ -473,7 +473,7 @@ RSpec.describe SmartParams do
       end
     end
 
-    context "specified with required subfield" do
+    context "specified with unclean data" do
       subject {nullable_required_subfield_schema.to_hash}
 
       let(:params) do
@@ -490,6 +490,24 @@ RSpec.describe SmartParams do
         expect {
           subject
         }.to raise_exception(SmartParams::Error::InvalidPropertyType)
+      end
+    end
+
+    context "specified as null" do
+      subject {nullable_required_subfield_schema.to_hash}
+
+      let(:params) do
+        {
+          # This will not raise an error, since data is allowed to be null.
+          # Subfields will not be checked.
+          data: nil
+        }
+      end
+
+      it "checks subfields" do
+        expect {
+          subject
+        }.not_to raise_exception(SmartParams::Error::InvalidPropertyType)
       end
     end
 

--- a/lib/smart_params_spec.rb
+++ b/lib/smart_params_spec.rb
@@ -3,6 +3,7 @@ require "spec_helper"
 RSpec.describe SmartParams do
   let(:schema) { CreateAccountSchema.new(params) }
   let(:nullable_schema) { NullableSchema.new(params) }
+  let(:nullable_required_subfield_schema) { NullableRequiredSubfieldSchema.new(params) }
 
   describe ".new" do
     context "with an empty params" do
@@ -469,6 +470,43 @@ RSpec.describe SmartParams do
             }
           )
         )
+      end
+    end
+
+    context "specified with required subfield" do
+      subject {nullable_required_subfield_schema.to_hash}
+
+      let(:params) do
+        {
+          # This will raise an exception becase the data hash is specified
+          # but its required subfields are not.
+          data: {
+            is: 'garbage'
+          }
+        }
+      end
+
+      it "checks subfields" do
+        expect {
+          subject
+        }.to raise_exception(SmartParams::Error::InvalidPropertyType)
+      end
+    end
+
+    context "unspecified with required subfield" do
+      subject {nullable_required_subfield_schema.to_hash}
+
+      let(:params) do
+        {
+          # In this case, the nullable data hash is not specified so we
+          # don't need to enforce constraints on subfields.
+        }
+      end
+
+      it "allows null value" do
+        expect {
+          subject
+        }.not_to raise_error
       end
     end
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -32,6 +32,17 @@ class NullableSchema
   end
 end
 
+class NullableRequiredSubfieldSchema
+  include SmartParams
+
+  schema type: Strict::Hash do
+    field :data, type: Strict::Hash | Strict::Nil, nullable: true do
+      field :id, type: Coercible::String
+      field :type, type: Strict::String
+    end
+  end
+end
+
 RSpec.configure do |let|
   # Enable flags like --only-failures and --next-failure
   let.example_status_persistence_file_path = ".rspec_status"


### PR DESCRIPTION
This feature lets you enforce constraints on the schema of nullable hashes without inadvertently making that hash required. When the hash is null, subfields are not considered and their constraints are not enforced. Juicy details on 733c93c.