### PR TITLE
Setting nullable to adds Nil to compound type

### DIFF
--- a/lib/smart_params/field.rb
+++ b/lib/smart_params/field.rb
@@ -92,6 +92,9 @@ module SmartParams
     end
 
     private def field(key, type:, nullable: false, &subfield)
+      if nullable
+        type |= SmartParams::Strict::Nil
+      end
       @subfields << self.class.new(keychain: [*keychain, key], type: type, nullable: nullable, &subfield)
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -36,7 +36,7 @@ class NullableRequiredSubfieldSchema
   include SmartParams
 
   schema type: Strict::Hash do
-    field :data, type: Strict::Hash | Strict::Nil, nullable: true do
+    field :data, type: Strict::Hash, nullable: true do
       field :id, type: Coercible::String
       field :type, type: Strict::String
     end


### PR DESCRIPTION
QOL change.

This change removes the need to explicitly specify a parameter as allowing
nil when nullable is true, e.g.

``` ruby
schema type: Strict::Hash do
  field :data, Strict::Hash, nullable: true do
    # ...
  end
end
```

An empty hash (with no data hash provided) will be considered valid input
for the above schema.