### PR TITLE
Attempting to create a machine that returns multiple errors and not just the first

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -47,3 +47,5 @@ RSpec/MultipleExpectations:
   Enabled: false
 Naming/RescuedExceptionsVariableName:
   Enabled: false
+RSpec/NestedGroups:
+  Enabled: false

--- a/lib/smart_params.rb
+++ b/lib/smart_params.rb
@@ -24,10 +24,15 @@ module SmartParams
     @schema = self.class.instance_variable_get(:@schema)[name]
 
     @fields = [@schema, *unfold(@schema.subfields)].sort_by(&:weight).each { |field| field.claim(raw) }
+    binding.pry
   rescue SmartParams::Error::InvalidPropertyType => invalid_property_exception
     raise invalid_property_exception if safe?
 
     @exception = invalid_property_exception
+  end
+
+  def errors
+    fields.flat_map(&:errors).compact
   end
 
   def inspect

--- a/lib/smart_params_spec.rb
+++ b/lib/smart_params_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SmartParams do
       end
 
       it "throws an error with the missing property and given properties" do
-        expect { schema }.to raise_exception do |exception|
+        expect { schema }.to raise_exception(SmartParams::Error::InvalidPropertyType) do |exception|
           expect(exception).to have_attributes(keychain: [:data], wanted: a_kind_of(Dry::Types::Constrained), raw: nil)
         end
       end
@@ -30,7 +30,21 @@ RSpec.describe SmartParams do
       end
 
       it "throws an error with the invalid property, expected type, given type, and given value" do
-        expect { schema }.to raise_exception do |exception|
+        expect { schema }.to raise_exception(SmartParams::Error::InvalidPropertyType) do |exception|
+          expect(exception).to have_attributes(keychain: [:data], wanted: a_kind_of(Dry::Types::Constrained), raw: "")
+        end
+      end
+    end
+
+    context "with multiple issues" do
+      let(:params) { { data: {y: 2, attributes: ""}, id: nil } }
+
+      it "throws an error with a message detailing the invalid property, expected type, given type, and given value" do
+        expect { schema }.to raise_exception(SmartParams::Error::InvalidPropertyType, "expected [:data] to be Hash, but is \"\"")
+      end
+
+      it "throws an error with the invalid property, expected type, given type, and given value" do
+        expect { schema }.to raise_exception(SmartParams::Error::InvalidPropertyType) do |exception|
           expect(exception).to have_attributes(keychain: [:data], wanted: a_kind_of(Dry::Types::Constrained), raw: "")
         end
       end


### PR DESCRIPTION
Right now when you attempt to pair up with a payload the interface will raise an exception at the first issue. Most of the time however this strict behavior is not desired, instead what is desired is to get a full lay of the issues.

I've tried to capture that behavior, but it's a bit finicky.